### PR TITLE
Guard against mWatcher not being initialized

### DIFF
--- a/src/win32/Controller.cpp
+++ b/src/win32/Controller.cpp
@@ -63,5 +63,5 @@ bool Controller::hasErrored() {
 }
 
 bool Controller::isWatching() {
-  return mWatcher->isRunning();
+  return mWatcher && mWatcher->isRunning();
 }


### PR DESCRIPTION
Fix our renderer process crashes by guarding against `mWatcher` not being initialized properly when the directory handle is invalid.