### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -1,7 +1,8 @@
 const nsfw = require('../src/');
 const path = require('path');
 const promisify = require('promisify-node');
-const fse = promisify(require('fs-extra'));
+const fs = promisify(require('fs'));
+const rimraf = promisify(require('rimraf'));
 const exec = promisify((command, options, callback) =>
   require('child_process').exec(command, options, callback));
 
@@ -15,19 +16,19 @@ describe('Node Sentinel File Watcher', function() {
 
   beforeEach(function(done) {
     function makeDir(identifier) {
-      return fse.mkdir(path.join(workDir, 'test' + identifier))
-        .then(() => fse.mkdir(path.join(workDir, 'test' + identifier, 'folder' + identifier)))
-        .then(() => fse.open(path.join(workDir, 'test' + identifier, 'testing' + identifier +'.file'), 'w'))
+      return fs.mkdir(path.join(workDir, 'test' + identifier))
+        .then(() => fs.mkdir(path.join(workDir, 'test' + identifier, 'folder' + identifier)))
+        .then(() => fs.open(path.join(workDir, 'test' + identifier, 'testing' + identifier +'.file'), 'w'))
         .then(fd => {
-          return fse.write(fd, 'testing')
+          return fs.write(fd, 'testing')
             .then(() => fd);
         })
-        .then(fd => fse.close(fd));
+        .then(fd => fs.close(fd));
     }
     // create a file System
-    return fse.stat(workDir)
-      .then(() => fse.remove(workDir), () => {})
-      .then(() => fse.mkdir(workDir))
+    return fs.stat(workDir)
+      .then(() => rimraf(workDir), () => {})
+      .then(() => fs.mkdir(workDir))
       .then(() => {
         const promises = [];
         for (let i = 0; i < 5; ++i) {
@@ -39,7 +40,7 @@ describe('Node Sentinel File Watcher', function() {
   });
 
   afterEach(function(done) {
-    return fse.remove(workDir)
+    return rimraf(workDir)
       .then(done);
   });
 
@@ -89,21 +90,21 @@ describe('Node Sentinel File Watcher', function() {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
         .then(() => {
-          const fd = fse.openSync(filePath, 'w');
-          fse.writeSync(fd, 'Bean bag video games at noon.');
-          return fse.close(fd);
+          const fd = fs.openSync(filePath, 'w');
+          fs.writeSync(fd, 'Bean bag video games at noon.');
+          return fs.close(fd);
         })
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
-        .then(() => fse.remove(filePath))
+        .then(() => rimraf(filePath))
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
         .then(() => {
-          const fd = fse.openSync(filePath, 'w');
-          fse.writeSync(fd, 'His watch has ended.');
-          return fse.close(fd);
+          const fd = fs.openSync(filePath, 'w');
+          fs.writeSync(fd, 'His watch has ended.');
+          return fs.close(fd);
         })
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
@@ -147,11 +148,11 @@ describe('Node Sentinel File Watcher', function() {
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
-        .then(() => fse.open(path.join(inPath, file), 'w'))
+        .then(() => fs.open(path.join(inPath, file), 'w'))
         .then(fd => {
-          return fse.write(fd, 'Peanuts, on occasion, rain from the skies.').then(() => fd);
+          return fs.write(fd, 'Peanuts, on occasion, rain from the skies.').then(() => fd);
         })
-        .then(fd => fse.close(fd))
+        .then(fd => fs.close(fd))
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
@@ -192,7 +193,7 @@ describe('Node Sentinel File Watcher', function() {
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
-        .then(() => fse.remove(path.join(inPath, file)))
+        .then(() => rimraf(path.join(inPath, file)))
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
@@ -233,11 +234,11 @@ describe('Node Sentinel File Watcher', function() {
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
-        .then(() => fse.open(path.join(inPath, file), 'w'))
+        .then(() => fs.open(path.join(inPath, file), 'w'))
         .then(fd => {
-          return fse.write(fd, 'At times, sunflower seeds are all that is life.').then(() => fd);
+          return fs.write(fd, 'At times, sunflower seeds are all that is life.').then(() => fd);
         })
-        .then(fd => fse.close(fd))
+        .then(fd => fs.close(fd))
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
@@ -283,30 +284,30 @@ describe('Node Sentinel File Watcher', function() {
         .then(() => nsfw(
           dirB,
           events => events.forEach(findEvent),
-          { debounceMS: DEBOUNCE })
-        .then(_w => {
+          { debounceMS: DEBOUNCE }
+        ).then(_w => {
           watchB = _w;
           return watchB.start();
         }))
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
-        .then(() => fse.open(path.join(dirA, fileA), 'w'))
+        .then(() => fs.open(path.join(dirA, fileA), 'w'))
         .then(fd => new Promise(resolve => {
           setTimeout(() => resolve(fd), TIMEOUT_PER_STEP);
         }))
         .then(fd => {
-          return fse.write(fd, 'At times, sunflower seeds are all that is life.').then(() => fd);
+          return fs.write(fd, 'At times, sunflower seeds are all that is life.').then(() => fd);
         })
-        .then(fd => fse.close(fd))
-        .then(() => fse.open(path.join(dirB, fileB), 'w'))
+        .then(fd => fs.close(fd))
+        .then(() => fs.open(path.join(dirB, fileB), 'w'))
         .then(fd => new Promise(resolve => {
           setTimeout(() => resolve(fd), TIMEOUT_PER_STEP);
         }))
         .then(fd => {
-          return fse.write(fd, 'At times, sunflower seeds are all that is life.').then(() => fd);
+          return fs.write(fd, 'At times, sunflower seeds are all that is life.').then(() => fd);
         })
-        .then(fd => fse.close(fd))
+        .then(fd => fs.close(fd))
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
@@ -358,11 +359,11 @@ describe('Node Sentinel File Watcher', function() {
           return paths.reduce((chain, dir) => {
             directory = path.join(directory, dir);
             const nextDirectory = directory;
-            return chain.then(() => fse.mkdir(nextDirectory));
+            return chain.then(() => fs.mkdir(nextDirectory));
           }, Promise.resolve());
         })
-        .then(() => fse.open(path.join(directory, file), 'w'))
-        .then(fd => fse.close(fd))
+        .then(() => fs.open(path.join(directory, file), 'w'))
+        .then(fd => fs.close(fd))
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
@@ -407,7 +408,7 @@ describe('Node Sentinel File Watcher', function() {
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
-        .then(() => fse.remove(inPath))
+        .then(() => rimraf(inPath))
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
@@ -420,8 +421,8 @@ describe('Node Sentinel File Watcher', function() {
     });
 
     it('does not loop endlessly when watching directories with recursive symlinks', (done) => {
-      fse.mkdirSync(path.join(workDir, 'test'));
-      fse.symlinkSync(path.join(workDir, 'test'), path.join(workDir, 'test', 'link'));
+      fs.mkdirSync(path.join(workDir, 'test'));
+      fs.symlinkSync(path.join(workDir, 'test'), path.join(workDir, 'test', 'link'));
 
       let watch;
 
@@ -460,7 +461,7 @@ describe('Node Sentinel File Watcher', function() {
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
-        .then(() => fse.remove(inPath))
+        .then(() => rimraf(inPath))
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
@@ -494,14 +495,14 @@ describe('Node Sentinel File Watcher', function() {
           watch = _w;
           return watch.start();
         })
-        .then(() => fse.remove(path.join(stressRepoPath, 'folder')))
+        .then(() => rimraf(path.join(stressRepoPath, 'folder')))
         .then(() => errorRestart)
         .then(() => {
           expect(count).toBeGreaterThan(0);
           return watch.stop();
         })
-        .then(() => fse.remove(stressRepoPath))
-        .then(() => fse.mkdir(stressRepoPath))
+        .then(() => rimraf(stressRepoPath))
+        .then(() => fs.mkdir(stressRepoPath))
         .then(() => nsfw(
           stressRepoPath,
           () => { count++; },
@@ -515,8 +516,8 @@ describe('Node Sentinel File Watcher', function() {
         .then(() => new Promise(resolve => setTimeout(resolve, TIMEOUT_PER_STEP)))
         .then(() =>
           exec('git clone https://github.com/implausible/nsfw-stress-test ' + path.join('nsfw-stress-test', 'test')))
-        .then(() => fse.stat(path.join(stressRepoPath, 'test')))
-        .then(() => fse.remove(path.join(stressRepoPath, 'test')))
+        .then(() => fs.stat(path.join(stressRepoPath, 'test')))
+        .then(() => rimraf(path.join(stressRepoPath, 'test')))
         .then(() => errorRestart)
         .then(() => {
           expect(count).toBeGreaterThan(0);
@@ -547,7 +548,7 @@ describe('Node Sentinel File Watcher', function() {
     });
 
     afterEach(function(done) {
-      return fse.remove(stressRepoPath)
+      return rimraf(stressRepoPath)
         .then(done);
     });
   });
@@ -555,7 +556,7 @@ describe('Node Sentinel File Watcher', function() {
   describe('Unicode support', function() {
     const watchPath = path.join(workDir, 'は');
     beforeEach(function(done) {
-      return fse.mkdir(watchPath)
+      return fs.mkdir(watchPath)
         .then(done);
     });
 
@@ -587,11 +588,11 @@ describe('Node Sentinel File Watcher', function() {
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
-        .then(() => fse.open(path.join(watchPath, file), 'w'))
+        .then(() => fs.open(path.join(watchPath, file), 'w'))
         .then(fd => {
-          return fse.write(fd, 'Unicode though.').then(() => fd);
+          return fs.write(fd, 'Unicode though.').then(() => fd);
         })
-        .then(fd => fse.close(fd))
+        .then(fd => fs.close(fd))
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))

--- a/js/spec/index-spec.js
+++ b/js/spec/index-spec.js
@@ -1,10 +1,16 @@
 const nsfw = require('../src/');
 const path = require('path');
-const promisify = require('promisify-node');
-const fs = promisify(require('fs'));
+const { promisify } = require('util');
+const fs = require('fs');
 const rimraf = promisify(require('rimraf'));
 const exec = promisify((command, options, callback) =>
   require('child_process').exec(command, options, callback));
+
+const mkdir = promisify(fs.mkdir);
+const open = promisify(fs.open);
+const write = promisify(fs.write);
+const stat = promisify(fs.stat);
+const close = promisify(fs.close);
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
 
@@ -16,19 +22,19 @@ describe('Node Sentinel File Watcher', function() {
 
   beforeEach(function(done) {
     function makeDir(identifier) {
-      return fs.mkdir(path.join(workDir, 'test' + identifier))
-        .then(() => fs.mkdir(path.join(workDir, 'test' + identifier, 'folder' + identifier)))
-        .then(() => fs.open(path.join(workDir, 'test' + identifier, 'testing' + identifier +'.file'), 'w'))
+      return mkdir(path.join(workDir, 'test' + identifier))
+        .then(() => mkdir(path.join(workDir, 'test' + identifier, 'folder' + identifier)))
+        .then(() => open(path.join(workDir, 'test' + identifier, 'testing' + identifier +'.file'), 'w'))
         .then(fd => {
-          return fs.write(fd, 'testing')
+          return write(fd, 'testing')
             .then(() => fd);
         })
-        .then(fd => fs.close(fd));
+        .then(fd => close(fd));
     }
     // create a file System
-    return fs.stat(workDir)
+    return stat(workDir)
       .then(() => rimraf(workDir), () => {})
-      .then(() => fs.mkdir(workDir))
+      .then(() => mkdir(workDir))
       .then(() => {
         const promises = [];
         for (let i = 0; i < 5; ++i) {
@@ -92,7 +98,7 @@ describe('Node Sentinel File Watcher', function() {
         .then(() => {
           const fd = fs.openSync(filePath, 'w');
           fs.writeSync(fd, 'Bean bag video games at noon.');
-          return fs.close(fd);
+          return close(fd);
         })
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
@@ -104,7 +110,7 @@ describe('Node Sentinel File Watcher', function() {
         .then(() => {
           const fd = fs.openSync(filePath, 'w');
           fs.writeSync(fd, 'His watch has ended.');
-          return fs.close(fd);
+          return close(fd);
         })
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
@@ -148,11 +154,11 @@ describe('Node Sentinel File Watcher', function() {
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
-        .then(() => fs.open(path.join(inPath, file), 'w'))
+        .then(() => open(path.join(inPath, file), 'w'))
         .then(fd => {
-          return fs.write(fd, 'Peanuts, on occasion, rain from the skies.').then(() => fd);
+          return write(fd, 'Peanuts, on occasion, rain from the skies.').then(() => fd);
         })
-        .then(fd => fs.close(fd))
+        .then(fd => close(fd))
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
@@ -234,11 +240,11 @@ describe('Node Sentinel File Watcher', function() {
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
-        .then(() => fs.open(path.join(inPath, file), 'w'))
+        .then(() => open(path.join(inPath, file), 'w'))
         .then(fd => {
-          return fs.write(fd, 'At times, sunflower seeds are all that is life.').then(() => fd);
+          return write(fd, 'At times, sunflower seeds are all that is life.').then(() => fd);
         })
-        .then(fd => fs.close(fd))
+        .then(fd => close(fd))
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
@@ -292,22 +298,22 @@ describe('Node Sentinel File Watcher', function() {
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
-        .then(() => fs.open(path.join(dirA, fileA), 'w'))
+        .then(() => open(path.join(dirA, fileA), 'w'))
         .then(fd => new Promise(resolve => {
           setTimeout(() => resolve(fd), TIMEOUT_PER_STEP);
         }))
         .then(fd => {
-          return fs.write(fd, 'At times, sunflower seeds are all that is life.').then(() => fd);
+          return write(fd, 'At times, sunflower seeds are all that is life.').then(() => fd);
         })
-        .then(fd => fs.close(fd))
-        .then(() => fs.open(path.join(dirB, fileB), 'w'))
+        .then(fd => close(fd))
+        .then(() => open(path.join(dirB, fileB), 'w'))
         .then(fd => new Promise(resolve => {
           setTimeout(() => resolve(fd), TIMEOUT_PER_STEP);
         }))
         .then(fd => {
-          return fs.write(fd, 'At times, sunflower seeds are all that is life.').then(() => fd);
+          return write(fd, 'At times, sunflower seeds are all that is life.').then(() => fd);
         })
-        .then(fd => fs.close(fd))
+        .then(fd => close(fd))
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
@@ -359,11 +365,11 @@ describe('Node Sentinel File Watcher', function() {
           return paths.reduce((chain, dir) => {
             directory = path.join(directory, dir);
             const nextDirectory = directory;
-            return chain.then(() => fs.mkdir(nextDirectory));
+            return chain.then(() => mkdir(nextDirectory));
           }, Promise.resolve());
         })
-        .then(() => fs.open(path.join(directory, file), 'w'))
-        .then(fd => fs.close(fd))
+        .then(() => open(path.join(directory, file), 'w'))
+        .then(fd => close(fd))
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
@@ -502,7 +508,7 @@ describe('Node Sentinel File Watcher', function() {
           return watch.stop();
         })
         .then(() => rimraf(stressRepoPath))
-        .then(() => fs.mkdir(stressRepoPath))
+        .then(() => mkdir(stressRepoPath))
         .then(() => nsfw(
           stressRepoPath,
           () => { count++; },
@@ -516,7 +522,7 @@ describe('Node Sentinel File Watcher', function() {
         .then(() => new Promise(resolve => setTimeout(resolve, TIMEOUT_PER_STEP)))
         .then(() =>
           exec('git clone https://github.com/implausible/nsfw-stress-test ' + path.join('nsfw-stress-test', 'test')))
-        .then(() => fs.stat(path.join(stressRepoPath, 'test')))
+        .then(() => stat(path.join(stressRepoPath, 'test')))
         .then(() => rimraf(path.join(stressRepoPath, 'test')))
         .then(() => errorRestart)
         .then(() => {
@@ -556,7 +562,7 @@ describe('Node Sentinel File Watcher', function() {
   describe('Unicode support', function() {
     const watchPath = path.join(workDir, 'は');
     beforeEach(function(done) {
-      return fs.mkdir(watchPath)
+      return mkdir(watchPath)
         .then(done);
     });
 
@@ -588,11 +594,11 @@ describe('Node Sentinel File Watcher', function() {
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))
-        .then(() => fs.open(path.join(watchPath, file), 'w'))
+        .then(() => open(path.join(watchPath, file), 'w'))
         .then(fd => {
-          return fs.write(fd, 'Unicode though.').then(() => fd);
+          return write(fd, 'Unicode though.').then(() => fd);
         })
-        .then(fd => fs.close(fd))
+        .then(fd => close(fd))
         .then(() => new Promise(resolve => {
           setTimeout(resolve, TIMEOUT_PER_STEP);
         }))

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "acorn": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
-      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -98,38 +98,12 @@
       "dev": true,
       "optional": true
     },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
       "dev": true,
       "optional": true
-    },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "async-each": {
       "version": "1.0.1",
@@ -915,21 +889,6 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "^5.0.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "rimraf": "^2.2.8"
-      }
-    },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -950,14 +909,14 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.45",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
-      "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
+      "version": "0.10.50",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
       "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
         "es6-symbol": "~3.1.1",
-        "next-tick": "1"
+        "next-tick": "^1.0.0"
       }
     },
     "es6-iterator": {
@@ -1221,14 +1180,14 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
         "circular-json": "^0.3.1",
-        "del": "^2.0.2",
         "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
         "write": "^0.2.1"
       }
     },
@@ -1247,16 +1206,6 @@
       "optional": true,
       "requires": {
         "for-in": "^1.0.1"
-      }
-    },
-    "fs-extra": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.0.tgz",
-      "integrity": "sha512-EglNDLRpmaTWiD/qraZn6HREAEAHJcJOmxNEYwq6xeMKnVMAy3GUcFB+wXt2C6k4CNvB/mP1y/U3dzvKKj5OtQ==",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
       }
     },
     "fs-readdir-recursive": {
@@ -1810,10 +1759,13 @@
       }
     },
     "generate-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
-      "dev": true
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dev": true,
+      "requires": {
+        "is-property": "^1.0.2"
+      }
     },
     "generate-object-property": {
       "version": "1.2.0",
@@ -1864,20 +1816,6 @@
       "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
-    "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      }
-    },
     "globule": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
@@ -1892,7 +1830,8 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -2063,9 +2002,9 @@
       "dev": true
     },
     "is-my-json-valid": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.18.0.tgz",
-      "integrity": "sha512-DWT87JHCSdCPCxbqBpS6Z2ajAt+MvrJq8I4xrpQljCvzODO5/fiquBp20a3sN6yCJvFbCRyYvJOHjpzkPTKJyA==",
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
+      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
       "dev": true,
       "requires": {
         "generate-function": "^2.0.0",
@@ -2083,30 +2022,6 @@
       "optional": true,
       "requires": {
         "kind-of": "^3.0.2"
-      }
-    },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "^1.0.0"
-      }
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "^1.0.1"
       }
     },
     "is-posix-bracket": {
@@ -2209,9 +2124,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -2238,14 +2153,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
-    },
-    "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "requires": {
-        "graceful-fs": "^4.1.6"
-      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -2283,16 +2190,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
-    },
-    "lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
-    },
-    "lodash.isundefined": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isundefined/-/lodash.isundefined-3.0.1.tgz",
-      "integrity": "sha1-I+89lTVWUgOmbO/VuDD4SJEa+0g="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -2379,14 +2276,6 @@
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
-    "nodegit-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/nodegit-promise/-/nodegit-promise-4.0.0.tgz",
-      "integrity": "sha1-VyKxhPLfcycWEGSnkdLoQskWezQ=",
-      "requires": {
-        "asap": "~2.0.3"
-      }
-    },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -2405,7 +2294,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object.omit": {
       "version": "2.0.1",
@@ -2429,7 +2319,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -2495,27 +2385,6 @@
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-      "dev": true
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
-    },
     "pluralize": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
@@ -2552,15 +2421,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
-    },
-    "promisify-node": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/promisify-node/-/promisify-node-0.5.0.tgz",
-      "integrity": "sha512-GR2E4qgCoKFTprhULqP2OP3bl8kHo16XtnqtkHH6be7tPW1yL6rXd15nl3oV2sLTFv1+j6tqoF69VVpFtJ/j+A==",
-      "requires": {
-        "nodegit-promise": "^4.0.0",
-        "object-assign": "^4.1.1"
-      }
     },
     "randomatic": {
       "version": "3.1.0",
@@ -2751,12 +2611,28 @@
       }
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "run-async": {
@@ -2964,11 +2840,6 @@
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
       "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
       "dev": true
-    },
-    "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "user-home": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -27,17 +27,14 @@
   ],
   "homepage": "https://github.com/axosoft/node-simple-file-watcher",
   "dependencies": {
-    "fs-extra": "^7.0.0",
-    "lodash.isinteger": "^4.0.4",
-    "lodash.isundefined": "^3.0.1",
-    "nan": "^2.10.0",
-    "promisify-node": "^0.5.0"
+    "nan": "^2.10.0"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",
     "babel-preset-es2015": "^6.5.0",
     "eslint": "^2.2.0",
-    "jasmine-node": "^2.0.0"
+    "jasmine-node": "^2.0.0",
+    "rimraf": "^2.6.3"
   },
   "keywords": [
     "FileWatcher",


### PR DESCRIPTION
This PR gets rid of `fs-extra`, `lodash.isinteger`, `loadash.isundefined` and `promisify-node` from the list of dependencies of `nsfw`.

These packages and their dependencies contribute to [92 modules](https://gist.github.com/rafeca/55d626797721c13c7251a205fef84a25) that need to be loaded, parsed and evaluated during the startup of Atom (out of ~400 total modules loaded).

* `lodash.isinteger` has been replaced by `Number.isInteger`.
* `lodash.isundefined` has been replaced by strict checks against `undefined`.
* `promisify-node` has been replaced by the core [`util.promisify`](https://nodejs.org/dist/latest-v8.x/docs/api/util.html#util_util_promisify_original) node API.
* `fs-extra` has been replaced by the core `fs` module (only `stat` method was used on the package logic). For tests, I've replaced `fs.remove()` by `rimraf`).

This is part of the initiative to reduce the number of modules loaded during startup. More info: https://github.com/atom/atom/issues/19269
