### PR TITLE
Synchronize deletion of mInterface in NSFW destructor

### DIFF
--- a/src/NSFW.cpp
+++ b/src/NSFW.cpp
@@ -26,13 +26,15 @@ NSFW::NSFW(uint32_t debounceMS, std::string path, Callback *eventCallback, Callb
   }
 
 NSFW::~NSFW() {
-  if (mInterface != NULL) {
-    delete mInterface;
-  }
   delete mEventCallback;
   delete mErrorCallback;
 
   if (mInterfaceLockValid) {
+    uv_mutex_lock(&mInterfaceLock);
+    if (mInterface != NULL) {
+      delete mInterface;
+    }
+    uv_mutex_unlock(&mInterfaceLock);
     uv_mutex_destroy(&mInterfaceLock);
   }
 }


### PR DESCRIPTION
We're seeing intermittent crashes on Windows calling `mInterface->isWatching()` in `StartWorker::Execute` on a background thread. The only unsynchronized access to mInterface that we can find takes place in the destructor of NSFW itself, making us wonder if interleaved calls to start and stop might be causing the following race condition.

* Start is called and sets the persistent handle to prevent the `NSFW` from being garbage collected
* Stop is called
* Before the StopWorker's `HandleOkCallback` runs and clears the 
persistent handle, we call start again
* Start spawns a worker thread
* Stop's ok callback clears the persistent handle, leaving the `NSFW` free to be collected as garbage
* The garbage collector runs and runs the destructor on the `NSFW` object, 
which clears the `mInterface` field
* The `StartWorker` accesses the `mInterface` pointer on a background thread, which now points to a deleted object

We don't have proof that this is what is happening, but if it is, I'm hoping that locking the field access in the destructor would prevent it.

I want to do some more local testing on Windows to see if I can reproduce the crash again without this change, then spend 2-3x more time running with this change to see if it avoids the crash. 😓

cc @as-cii @rafeca