### PR TITLE
Update from nsfw/master to include memory leak fixes

### DIFF
--- a/src/linux/InotifyEventLoop.cpp
+++ b/src/linux/InotifyEventLoop.cpp
@@ -38,9 +38,9 @@ void InotifyEventLoop::work() {
     }
 
     if (isDirectoryEvent) {
-      inotifyService->createDirectory(event->wd, strdup(event->name));
+      inotifyService->createDirectory(event->wd, event->name);
     } else {
-      inotifyService->create(event->wd, strdup(event->name));
+      inotifyService->create(event->wd, event->name);
     }
   };
 
@@ -49,7 +49,7 @@ void InotifyEventLoop::work() {
       return;
     }
 
-    inotifyService->modify(event->wd, strdup(event->name));
+    inotifyService->modify(event->wd, event->name);
   };
 
   auto remove = [&event, &isDirectoryRemoval, &inotifyService]() {
@@ -60,7 +60,7 @@ void InotifyEventLoop::work() {
     if (isDirectoryRemoval) {
       inotifyService->removeDirectory(event->wd);
     } else {
-      inotifyService->remove(event->wd, strdup(event->name));
+      inotifyService->remove(event->wd, event->name);
     }
   };
 
@@ -133,7 +133,7 @@ void InotifyEventLoop::work() {
 
         renameStart();
       } else if (event->mask & (uint32_t)IN_MOVE_SELF) {
-        inotifyService->remove(event->wd, strdup(event->name));
+        inotifyService->remove(event->wd, event->name);
         inotifyService->removeDirectory(event->wd);
       }
     } while((position += sizeof(struct inotify_event) + event->len) < bytesRead);


### PR DESCRIPTION
Closes #7 

This pull request updates this fork to include some changes in [Axosoft/nsfw](https://github.com/axosoft/nsfw) that mitigate a memory leak on Linux. According to https://github.com/Axosoft/nsfw/pull/74 there may still be memory leaks, but I don't think those are platform-dependent (i.e., they are related to how events are stored, which is the same across operating systems).

I tested those changes out on a Ubuntu VM, and I confirm they fix the issue. Memory usage stops growing unbounded, and using the reproduction steps in #7 memory stays capped at ~100MB (still more than I would like it to be, but at least it doesn't keep growing forever and is consistent with other platforms).