### PR TITLE
Poll directory changes before resolving start promise on Windows

### DIFF
--- a/src/win32/Watcher.cpp
+++ b/src/win32/Watcher.cpp
@@ -236,8 +236,8 @@ void Watcher::start() {
 
   QueueUserAPC([](__in ULONG_PTR self) {
     auto watcher = reinterpret_cast<Watcher*>(self);
-    watcher->mHasStartedSemaphore.signal();
     watcher->pollDirectoryChanges();
+    watcher->mHasStartedSemaphore.signal();
   } , mRunner.native_handle(), (ULONG_PTR)this);
 
   if (!mHasStartedSemaphore.waitFor(std::chrono::seconds(10))) {


### PR DESCRIPTION
Refs: https://github.com/atom/atom/issues/19507
Refs: https://github.com/atom/atom/issues/19442#issuecomment-499433407

When watching a path on Windows, a new thread gets spawned and a function is scheduled to be executed onto such thread. This function's responsibility is to invoke `ReadDirectoryChangesW` for the first time and to wake up the thread which invoked `Watcher::start`, signaling that nsfw is ready to report events.

Previously, the main thread would be woken up _before_ calling `ReadDirectoryChangesW`. If any event occurred before or as `ReadDirectoryChangesW` took place, it wouldn't be reported to clients because that API only reports changes that occur _between_ calls to it. This is an excerpt [from MSDN](https://docs.microsoft.com/en-us/windows/desktop/api/winbase/nf-winbase-readdirectorychangesw):

> When you first call ReadDirectoryChangesW, the system allocates a buffer to store change information. This buffer is associated with the directory handle until it is closed and its size does not change during its lifetime. Directory changes that occur between calls to this function are added to the buffer and then returned with the next call. 

This pull request fixes the issue by waiting for `ReadDirectoryChangesW` to have been called before waking up the main thread. This ensures that file system events occurring after watching has started  are always reported to clients.

/cc: @jasonrudolph @rafeca @nathansobo 