### PR TITLE
binding.gyp: Use C++ 14 for Electron 11 support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -41,7 +41,7 @@
                 "xcode_settings": {
                     'MACOSX_DEPLOYMENT_TARGET': '10.7',
                     "OTHER_CFLAGS": [
-                        "-std=c++11",
+                        "-std=c++14",
                         "-stdlib=libc++"
                     ],
                 },
@@ -67,7 +67,7 @@
                 ],
                 "cflags": [
                     "-Wno-unknown-pragmas",
-                    "-std=c++11"
+                    "-std=c++14"
                 ]
             }],
             ["OS=='win'", {


### PR DESCRIPTION
### Quick Summary

Electron 11 has a newer V8 engine, which apparently requires building with C++ 14 or newer.

This Pull Request bumps the C++ standard in `binding.gyp` so `node-gyp` will compile it in a way that is compatible with Electron 11.

<details><summary><b>Requirements for Contributing a Bug Fix (from template, click to expand)</b></summary>

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix an existing bug. To contribute other changes, you must use a different template. You can see all templates at <https://github.com/atom/.github/tree/master/.github/PULL_REQUEST_TEMPLATE>.
* The pull request must update the test suite to demonstrate the changed functionality. For guidance, please see <https://flight-manual.atom.io/hacking-atom/sections/writing-specs/>.
* After you create the pull request, all status checks must be pass before a maintainer reviews your contribution. For more details, please see <https://github.com/atom/.github/tree/master/CONTRIBUTING.md#pull-requests>.

</details>

### Identify the Bug

<!--

Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Helps with https://github.com/atom/atom/pull/22687, see other modules that needed this same bump: https://github.com/atom/atom/pull/22687#issuecomment-873614970

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

In `binding.gyp` (which is read and interpreted by [`node-gyp`](https://github.com/nodejs/node-gyp)), specify that compilers should use the C++ 14 standard when compiling this module's native C++ code, rather than the older C++ 11 standard that is no-longer supported in the latest V8 JS engine. Electron 11 comes with a newer V8 version.

I gathered most of this information from the comments in this issue: https://github.com/electron/electron/issues/26364

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

We could bump to an even newer C++ standard (C++ 17, C++ 20)
 
### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None

### Verification Process

<!--

What process did you follow to verify that the change has not introduced any regressions? Describe the actions you performed (including buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Allows Atom CI to proceed past building this package. See my CI runs: https://dev.azure.com/DeeDeeG/b/_build?definitionId=15&_a=summary&branchFilter=182%2C182%2C182%2C182%2C182%2C182

- Before: https://dev.azure.com/DeeDeeG/b/_build/results?buildId=1175 (error during bootstrapping on macOS, upon trying to build `@atom/nsfw`.)
- After: https://dev.azure.com/DeeDeeG/b/_build/results?buildId=1176 (bootstrapping on macOS gets a little further, failing on a different package.)

### Release Notes

<!--

Please describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be used in Atom's release notes.

If this change is not user-facing or notable enough to be included in release notes
you may use the strings "Not applicable" or "N/A" here.

Examples:

- The GitHub package now allows you to add co-authors to commits.
- Fixed an issue where multiple cursors did not work in a file with a single line.
- Increased the performance of searching and replacing across a whole project.

-->

Compile as C++ 14 for compatibility with Electron 11